### PR TITLE
Fix IDEX-1379 Ability to stop run earlier

### DIFF
--- a/codenvy-api-runner/src/main/java/com/codenvy/api/runner/RunnerService.java
+++ b/codenvy-api-runner/src/main/java/com/codenvy/api/runner/RunnerService.java
@@ -153,7 +153,7 @@ public class RunnerService extends Service {
                                              @ApiParam(value = "Run ID", required = true)
                                              @PathParam("id") Long id) throws Exception {
         final RunQueueTask task = runQueue.getTask(id);
-        task.cancel();
+        task.stop();
         return task.getDescriptor();
     }
 

--- a/codenvy-api-runner/src/main/java/com/codenvy/api/runner/internal/Runner.java
+++ b/codenvy-api-runner/src/main/java/com/codenvy/api/runner/internal/Runner.java
@@ -258,7 +258,7 @@ public abstract class Runner {
         return doExecute(request, callback);
     }
 
-    protected RunnerProcess doExecute(final RunRequest request, RunnerProcess.Callback callback) throws RunnerException {
+    protected RunnerProcess doExecute(final RunRequest request, final RunnerProcess.Callback callback) throws RunnerException {
         final long startTime = System.currentTimeMillis();
         final RunnerConfiguration runnerCfg = getRunnerConfigurationFactory().createRunnerConfiguration(request);
         final int mem = runnerCfg.getMemory();
@@ -289,6 +289,8 @@ public abstract class Runner {
                     watcher.start(new Cancellable() {
                         @Override
                         public void cancel() throws Exception {
+                            process.getLogger()
+                                   .writeLine("[ERROR] Your run has been shutdown due to timeout. Upgrade your account to get an always on runner.");
                             process.internalStop(true);
                         }
                     });


### PR DESCRIPTION
With a new method RunQueue#stop called from RunnerService#stop the run
can now be put in a clean stop status just after having been launched.
It gives a clear distinction between user triggered stop and failure
cancellation.
