### PR TITLE
update pom.xml : add pluginRepositories to fix mvn install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,4 +57,11 @@
             <url>https://maven.codenvycorp.com/content/groups/public/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codenvy-public-repo</id>
+            <name>codenvy public</name>
+            <url>https://maven.codenvycorp.com/content/groups/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
when we launch mvn install, we have an error build

[ERROR] Failed to execute goal com.mycila:license-maven-plugin:2.6:check (check-headers) on project codenvy-platform-api-parent: Execution check-headers of goal com.mycila:license-maven-plugin:2.6:check failed: Plugin com.mycila:license-maven-plugin:2.6 or one of its dependencies could not be resolved: Failure to find com.codenvy.resources:codenvy-eclipse-license-resource-bundle:jar