### PR TITLE
Adding Codenvy plugin repository to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,4 +57,11 @@
             <url>https://maven.codenvycorp.com/content/groups/public/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codenvy</id>
+            <name>Maven Plugin Repository</name>
+            <url>http://maven.codenvycorp.com/content/repositories/codenvy-public-releases/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
Adding Codenvy plugin repository to pom.xml. This in needed in order to compile the project out-of-the-box, without manually adding the repository to maven settings.