### PR TITLE
Made JsonSerializable interface extend Serializable interface

### DIFF
--- a/codenvy-dto/src/main/java/org/eclipse/che/dto/server/JsonSerializable.java
+++ b/codenvy-dto/src/main/java/org/eclipse/che/dto/server/JsonSerializable.java
@@ -13,8 +13,10 @@
 // limitations under the License.
 package org.eclipse.che.dto.server;
 
+import java.io.Serializable;
+
 /** An entity that may serialize itself to JSON. */
-public interface JsonSerializable {
+public interface JsonSerializable extends Serializable {
 
     /** Serializes DTO to JSON format. */
     String toJson();


### PR DESCRIPTION
Added this for JsonStringMap to be serializable by JPA, this is needed for saving Che data model in database. Additionally in my opinion it makes sense to make custom serializable interface compliant with standard one. This change includes no run time overhead.